### PR TITLE
Update all the alerts if there is a change in Non-exportedParams section

### DIFF
--- a/controllers/alertsconfig_controller.go
+++ b/controllers/alertsconfig_controller.go
@@ -172,11 +172,12 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			log.Info("alert successfully got created", "alertID", alert.ID)
 
 		} else {
-
 			alertID := alertHashMap[alertName].ID
 			alert.ID = &alertID
 			//TODO: Move this to common so it can be used for both wavefront and alerts config
 			//Update use case
+			// This can be changed to a common function that used by alertconfig and wavefrontalerts, because it is
+			// updating the wavefront alert
 			if err := r.WavefrontClient.UpdateAlert(ctx, &alert); err != nil {
 				r.Recorder.Event(&alertsConfig, v1.EventTypeWarning, err.Error(), "unable to update the alert")
 				state := alertmanagerv1alpha1.Error

--- a/controllers/alertsconfig_controller.go
+++ b/controllers/alertsconfig_controller.go
@@ -176,8 +176,6 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			alert.ID = &alertID
 			//TODO: Move this to common so it can be used for both wavefront and alerts config
 			//Update use case
-			// This can be changed to a common function that used by alertconfig and wavefrontalerts, because it is
-			// updating the wavefront alert
 			if err := r.WavefrontClient.UpdateAlert(ctx, &alert); err != nil {
 				r.Recorder.Event(&alertsConfig, v1.EventTypeWarning, err.Error(), "unable to update the alert")
 				state := alertmanagerv1alpha1.Error

--- a/controllers/alertsconfig_controller.go
+++ b/controllers/alertsconfig_controller.go
@@ -165,7 +165,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					CR: alertsConfig.Name,
 				},
 			}
-			if err := r.CommonClient.PatchWfAlertAndAlertsConfigStatus(ctx, &wfAlert, &alertsConfig, alertStatus); err != nil {
+			if err := r.CommonClient.PatchWfAlertAndAlertsConfigStatus(ctx, alertmanagerv1alpha1.Ready, &wfAlert, &alertsConfig, alertStatus); err != nil {
 				log.Error(err, "unable to patch wfalert and alertsconfig status objects")
 				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err)
 			}
@@ -191,7 +191,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			alertStatus := alertHashMap[alertName]
 			alertStatus.LastChangeChecksum = reqChecksum
 
-			if err := r.CommonClient.PatchWfAlertAndAlertsConfigStatus(ctx, &wfAlert, &alertsConfig, alertStatus); err != nil {
+			if err := r.CommonClient.PatchWfAlertAndAlertsConfigStatus(ctx, alertmanagerv1alpha1.Ready, &wfAlert, &alertsConfig, alertStatus); err != nil {
 				log.Error(err, "unable to patch wfalert and alertsconfig status objects")
 				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err)
 			}

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -194,7 +194,6 @@ func (r *Client) PatchWfAlertAndAlertsConfigStatus(
 ) error {
 	log := log.Logger(ctx, "controllers", "common", "PatchWfAlertAndAlertsConfigStatus")
 	log = log.WithValues("wfAlertCR", wfAlert.Name, "alertsConfigCR", alertsConfig.Name)
-	log.Info("Going inside PatchWfAlertAndAlertsConfigStatus")
 
 	alertStatusBytes, _ := json.Marshal(alertStatus)
 	patch := []byte(fmt.Sprintf("{\"status\":{\"state\": \"%s\", \"alertsStatus\":{\"%s\":%s}}}", state, wfAlert.Name, string(alertStatusBytes)))

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -184,23 +184,31 @@ func GetProcessedWFAlert(ctx context.Context, wfAlert *alertmanagerv1alpha1.Wave
 }
 
 //PatchWfAlertAndAlertsConfigStatus function patches the individual alert status for both wavefront alert and alerts config
-func (r *Client) PatchWfAlertAndAlertsConfigStatus(ctx context.Context, wfAlert *alertmanagerv1alpha1.WavefrontAlert, alertsConfig *alertmanagerv1alpha1.AlertsConfig, alertStatus alertmanagerv1alpha1.AlertStatus) error {
+func (r *Client) PatchWfAlertAndAlertsConfigStatus(
+	ctx context.Context,
+	state alertmanagerv1alpha1.State,
+	wfAlert *alertmanagerv1alpha1.WavefrontAlert,
+	alertsConfig *alertmanagerv1alpha1.AlertsConfig,
+	alertStatus alertmanagerv1alpha1.AlertStatus,
+	requeueTime ...float64,
+) error {
 	log := log.Logger(ctx, "controllers", "common", "PatchWfAlertAndAlertsConfigStatus")
 	log = log.WithValues("wfAlertCR", wfAlert.Name, "alertsConfigCR", alertsConfig.Name)
+	log.Info("Going inside PatchWfAlertAndAlertsConfigStatus")
 
 	alertStatusBytes, _ := json.Marshal(alertStatus)
-	patch := []byte(fmt.Sprintf("{\"status\":{\"state\": \"%s\", \"alertsStatus\":{\"%s\":%s}}}", alertmanagerv1alpha1.Ready, wfAlert.Name, string(alertStatusBytes)))
-	_, err := r.PatchStatus(ctx, alertsConfig, client.RawPatch(types.MergePatchType, patch), alertmanagerv1alpha1.Ready)
+	patch := []byte(fmt.Sprintf("{\"status\":{\"state\": \"%s\", \"alertsStatus\":{\"%s\":%s}}}", state, wfAlert.Name, string(alertStatusBytes)))
+	_, err := r.PatchStatus(ctx, alertsConfig, client.RawPatch(types.MergePatchType, patch), state, requeueTime...)
 	if err != nil {
 		log.Error(err, "unable to patch the status for alerts config object")
 		return err
 	}
-	wfAlertStatusPatch := []byte(fmt.Sprintf("{\"status\":{\"state\": \"%s\",\"alertsStatus\":{\"%s\":%s}}}", alertmanagerv1alpha1.Ready, alertsConfig.Name, string(alertStatusBytes)))
+	wfAlertStatusPatch := []byte(fmt.Sprintf("{\"status\":{\"state\": \"%s\",\"alertsStatus\":{\"%s\":%s}}}", state, alertsConfig.Name, string(alertStatusBytes)))
 	if err != nil {
 		log.Error(err, "unable to patch the status for wavefront alert object")
 		return err
 	}
-	_, err = r.PatchStatus(ctx, wfAlert, client.RawPatch(types.MergePatchType, wfAlertStatusPatch), alertmanagerv1alpha1.Ready)
+	_, err = r.PatchStatus(ctx, wfAlert, client.RawPatch(types.MergePatchType, wfAlertStatusPatch), state, requeueTime...)
 	log.Info("alert successfully got updated for both wavefront alert and alerts config objects")
 
 	return nil

--- a/controllers/wavefrontalert_controller.go
+++ b/controllers/wavefrontalert_controller.go
@@ -402,7 +402,6 @@ func (r *WavefrontAlertReconciler) UpdateIndividualWavefrontAlert(
 	if err := r.WavefrontClient.UpdateAlert(ctx, &alert); err != nil {
 		return err
 	}
-	// We do not need to update individual alertStatus here because there is no change in alertsConfig
 	log.Info("alert successfully got updated", "alertID", alert.ID)
 	return nil
 }

--- a/controllers/wavefrontalert_controller.go
+++ b/controllers/wavefrontalert_controller.go
@@ -164,7 +164,6 @@ func (r *WavefrontAlertReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 			err := r.UpdateIndividualWavefrontAlert(ctx, req, c, alertsConfig, wfAlert)
 			if err != nil {
-				log.Info("UpdateIndividualWavefrontAlert was failed")
 				state := alertmanagerv1alpha1.Error
 				if strings.Contains(err.Error(), "Exceeded limit setting") {
 					state = alertmanagerv1alpha1.ClientExceededLimit

--- a/controllers/wavefrontalert_controller.go
+++ b/controllers/wavefrontalert_controller.go
@@ -114,32 +114,25 @@ func (r *WavefrontAlertReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		//That's fine- Let it come for requeue and we can create the alert
 		return ctrl.Result{}, nil
 	}
-
 	// Calculate the checksum
 	data, err := json.Marshal(wfAlert.Spec)
 	if err != nil {
-		log.Error(err, "unable to convert wavefront spec into string")
-		//This is probably rare scenario
-		state := alertmanagerv1alpha1.Error
-		//This is to avoid overwriting the other fields in status
-		wfAlert.Status.RetryCount = wfAlert.Status.RetryCount + 1
-		wfAlert.Status.ErrorDescription = err.Error()
-		wfAlert.Status.State = state
-		return r.CommonClient.UpdateStatus(ctx, &wfAlert, state, errRequeueTime)
+		return r.UpdateIndividualWavefrontAlertStatusError(ctx, &wfAlert, alertmanagerv1alpha1.Error, err, errRequeueTime)
 	}
 	lastChangeChecksum := utils.CalculateChecksum(ctx, string(data))
 	wfAlert.Status.LastChangeChecksum = lastChangeChecksum
 	// Check for exportedParams length
-	length := 0
+	exportedParamslength := 0
 	proceed := true
 	if wfAlert.Spec.ExportedParams != nil {
-		length = len(wfAlert.Spec.ExportedParams)
+		exportedParamslength = len(wfAlert.Spec.ExportedParams)
 	}
-	if wfAlert.Status.ObservedGeneration == wfAlert.ObjectMeta.Generation {
+
+	if wfAlert.Status.ObservedGeneration == wfAlert.ObjectMeta.Generation && wfAlert.Status.State != alertmanagerv1alpha1.Error {
 		proceed = false
 	}
 
-	if length > 0 {
+	if exportedParamslength > 0 {
 		// Check for exportedParams checksum
 		exist, reqChecksum := utils.ExportParamsChecksum(ctx, wfAlert.Spec.ExportedParams)
 		// if status doesn't have checksum- it means its very first request
@@ -153,7 +146,32 @@ func (r *WavefrontAlertReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 		}
 	}
+	// If user changed exported params and wavefront alert spec (ObservedGeneration) at the same time, we cannot perform any
+	// change because we need the substituted value of that exported param
+	// If there is a change in wavefront alert spec (ObservedGeneration) and NO CHANGE in exported Params,
+	// we need to loop through all the alertsconfig CR under status
+	// and fill up with the substituted params value then apply the change in wavefront for individual alert
+	if exportedParamslength > 0 && proceed && wfAlert.Status.ObservedGeneration != wfAlert.ObjectMeta.Generation {
+		// wavefrontalerts spec change
+		log.Info("wavefrontalerts spec was changed, processing to update individual alert that associated with it")
+		wfAlert.Status.LastChangeChecksum = lastChangeChecksum
+		for _, c := range wfAlert.Status.AlertsStatus {
+			err := r.UpdateIndividualWavefrontAlert(ctx, req, c, wfAlert)
+			if err != nil {
+				state := alertmanagerv1alpha1.Error
+				if strings.Contains(err.Error(), "Exceeded limit setting") {
+					state = alertmanagerv1alpha1.ClientExceededLimit
+				}
+				return r.UpdateIndividualWavefrontAlertStatusError(ctx, &wfAlert, state, err, errRequeueTime)
+			}
+		}
+		wfAlert.Status.ObservedGeneration = wfAlert.ObjectMeta.Generation
+		// We are going to stop here because we already updated individual alerts that associate with
+		// this wavefront alert template
+		return ctrl.Result{}, r.Status().Update(ctx, &wfAlert)
+	}
 
+	wfAlert.Status.ObservedGeneration = wfAlert.ObjectMeta.Generation
 	if !proceed {
 		// do nothing
 		log.Info("There is no change in the spec.. skipping")
@@ -165,16 +183,8 @@ func (r *WavefrontAlertReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	var alert wf.Alert
 	r.convertAlertCR(ctx, &wfAlert, &alert)
 	if err := wavefront.ValidateAlertInput(ctx, &alert); err != nil {
-		r.Recorder.Event(&wfAlert, v1.EventTypeWarning, err.Error(), "alert input request validation failed")
-		state := alertmanagerv1alpha1.Error
-		log.Error(err, "alert input request validation failed")
-		//This is to avoid overwriting the other fields in status
-		wfAlert.Status.RetryCount = wfAlert.Status.RetryCount + 1
-		wfAlert.Status.ErrorDescription = err.Error()
-		wfAlert.Status.State = state
-		//This might get tricky- if user rollsback the change- Keep it open until enough testing is done
 		wfAlert.Status.LastChangeChecksum = lastChangeChecksum
-		return r.CommonClient.UpdateStatus(ctx, &wfAlert, state, errRequeueTime)
+		return r.UpdateIndividualWavefrontAlertStatusError(ctx, &wfAlert, alertmanagerv1alpha1.Error, err, errRequeueTime)
 	}
 
 	// so simple validation is done so lets Handle reconcile
@@ -188,24 +198,17 @@ func (r *WavefrontAlertReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		// First time use case
 		// Lets create an alert
 		var alert wf.Alert
-
 		r.convertAlertCR(ctx, &wfAlert, &alert)
 		log.V(1).Info("alert values", "alertObj", alert)
 		if err := r.WavefrontClient.CreateAlert(ctx, &alert); err != nil {
-			r.Recorder.Event(&wfAlert, v1.EventTypeWarning, err.Error(), "unable to create the alert")
 			state := alertmanagerv1alpha1.Error
 			if strings.Contains(err.Error(), "Exceeded limit setting") {
 				// For ex: error is "Exceeded limit setting: 100 alerts allowed per customer"
 				state = alertmanagerv1alpha1.ClientExceededLimit
 			}
 			log.Error(err, "unable to create the alert")
-			wfAlert.Status = alertmanagerv1alpha1.WavefrontAlertStatus{
-				RetryCount:         wfAlert.Status.RetryCount + 1,
-				ErrorDescription:   err.Error(),
-				State:              state,
-				LastChangeChecksum: lastChangeChecksum,
-			}
-			return r.CommonClient.UpdateStatus(ctx, &wfAlert, state, errRequeueTime)
+			wfAlert.Status.LastChangeChecksum = lastChangeChecksum
+			return r.UpdateIndividualWavefrontAlertStatusError(ctx, &wfAlert, state, err, errRequeueTime)
 		}
 
 		alertResponse := alertmanagerv1alpha1.AlertStatus{
@@ -223,6 +226,7 @@ func (r *WavefrontAlertReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// existing alert - Perform the updateAlert one by one
+	// this is for standalone alerts not alertsconfig scenario
 	currStatus := wfAlert.Status.AlertsStatus
 	for _, a := range wfAlert.Status.AlertsStatus {
 		alert := wf.Alert{
@@ -241,7 +245,7 @@ func (r *WavefrontAlertReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				// For ex: error is "Exceeded limit setting: 100 alerts allowed per customer"
 				state = alertmanagerv1alpha1.ClientExceededLimit
 			}
-			log.Error(err, "unable to create the alert")
+			log.Error(err, "unable to update the alert")
 			respAlert.State = state
 			respAlert.LastChangeChecksum = a.LastChangeChecksum
 			// if even one of the child got failed, make parent status as error
@@ -334,4 +338,58 @@ func (r *WavefrontAlertReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&alertmanagerv1alpha1.WavefrontAlert{}).
 		WithEventFilter(controllercommon.StatusUpdatePredicate{}).
 		Complete(r)
+}
+
+func (r *WavefrontAlertReconciler) UpdateIndividualWavefrontAlertStatusError(
+	ctx context.Context,
+	wfAlert *alertmanagerv1alpha1.WavefrontAlert,
+	state alertmanagerv1alpha1.State,
+	err error,
+	requeueTime ...float64,
+) (ctrl.Result, error) {
+	log := log.Logger(ctx, "controllers", "wavefrontalert_controller", "UpdateIndividualWavefrontAlertError")
+	log = log.WithValues("wavefront_cr", wfAlert.Name, "namespace", wfAlert.Namespace)
+
+	wfAlert.Status.RetryCount = wfAlert.Status.RetryCount + 1
+	wfAlert.Status.ErrorDescription = err.Error()
+	wfAlert.Status.State = state
+
+	log.Error(err, "error occurred in wavefront alert", "wavefrontAlert", wfAlert.Name)
+	r.Recorder.Event(wfAlert, v1.EventTypeWarning, err.Error(), fmt.Sprintf("error occurred in wavefront alert %s", wfAlert.Name))
+	return r.CommonClient.UpdateStatus(ctx, wfAlert, state, requeueTime[0])
+}
+
+func (r *WavefrontAlertReconciler) UpdateIndividualWavefrontAlert(
+	ctx context.Context,
+	req ctrl.Request,
+	alertStatus alertmanagerv1alpha1.AlertStatus,
+	wfAlert alertmanagerv1alpha1.WavefrontAlert,
+) error {
+	log := log.Logger(ctx, "controllers", "wavefrontalert_controller", "UpdateIndividualWavefrontAlert")
+	// Get alertsconfig CR
+	alertConfigNamespacedName := types.NamespacedName{Namespace: req.Namespace, Name: alertStatus.AssociatedAlertsConfig.CR}
+	var alertsConfig alertmanagerv1alpha1.AlertsConfig
+	if err := r.Get(ctx, alertConfigNamespacedName, &alertsConfig); err != nil {
+		return err
+	}
+	// Get the corresponding alert in alertsConfig
+	config := alertsConfig.Spec.Alerts[alertStatus.AssociatedAlert.CR]
+	var alert wf.Alert
+	// Create wavefront alert with proper substituted value of that exported param
+	if err := controllercommon.GetProcessedWFAlert(ctx, &wfAlert, &config, &alert); err != nil {
+		return err
+	}
+	// Update alert in wavefront
+	alert.ID = &alertStatus.ID
+	// Validate the alert request
+	if err := wavefront.ValidateAlertInput(ctx, &alert); err != nil {
+		return err
+	}
+
+	if err := r.WavefrontClient.UpdateAlert(ctx, &alert); err != nil {
+		return err
+	}
+	// We do not need to update individual alertStatus here because there is no change in alertsConfig
+	log.Info("alert successfully got updated", "alertID", alert.ID)
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	golang.org/x/mod v0.5.0 // indirect
-	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34 // indirect
 	golang.org/x/tools v0.1.5 // indirect
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -590,6 +590,10 @@ golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c h1:Lyn7+CqXIiC+LOR9aHD6jDK+h
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e h1:XMgFehsDnnLGtjvjOfqWSUzt0alpTR1RSEuznObga2c=
+golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34 h1:GkvMjFtXUmahfDtashnc1mnrCtuBVcwse5QV2lUk/tI=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/wavefront/validate.go
+++ b/pkg/wavefront/validate.go
@@ -25,11 +25,11 @@ func validateAlertConditions(ctx context.Context, input *wavefront.Alert) error 
 	if input.AlertType == wavefront.AlertTypeThreshold {
 		if len(input.Conditions) != 0 {
 			if err := validateThresholdLevels(ctx, utils.TrimSpacesMap(input.Conditions)); err != nil {
-				log.Error(err, "invalid severity mentioned in conditions")
+				log.Error(err, "validation failed: invalid severity mentioned in conditions")
 				return err
 			}
 		} else {
-			msg := fmt.Sprintf("conditions must not be empty")
+			msg := fmt.Sprintf("validation failed: conditions must not be empty")
 			err := errors.New(msg)
 			log.Error(err, msg)
 			return err
@@ -37,7 +37,7 @@ func validateAlertConditions(ctx context.Context, input *wavefront.Alert) error 
 
 	} else if input.AlertType == wavefront.AlertTypeClassic {
 		if input.Condition == "" {
-			msg := fmt.Sprintf("condition must not be empty")
+			msg := fmt.Sprintf("validation failed: condition must not be empty")
 			err := errors.New(msg)
 			log.Error(err, msg)
 			return err
@@ -45,17 +45,17 @@ func validateAlertConditions(ctx context.Context, input *wavefront.Alert) error 
 
 		if input.Severity != "" {
 			if err := validateSeverity(ctx, input.Severity); err != nil {
-				log.Error(err, "invalid severity mentioned in the request")
+				log.Error(err, "validation failed: invalid severity mentioned in the request")
 				return err
 			}
 		} else {
-			msg := fmt.Sprintf("severity must not be empty")
+			msg := fmt.Sprintf("validation failed: severity must not be empty")
 			err := errors.New(msg)
 			log.Error(err, msg)
 			return err
 		}
 	} else {
-		msg := fmt.Sprintf("invalid alert type: %s", input.AlertType)
+		msg := fmt.Sprintf("validation failed: invalid alert type: %s", input.AlertType)
 		err := errors.New(msg)
 		log.Error(err, msg)
 		return err


### PR DESCRIPTION
close #18 



**Could you share the solution in high level?**
1. If there is a change in wavefront alert spec (ObservedGeneration) and NO CHANGE in exported Params, we need to loop through all the alertsconfig CR under status and fill up with the substituted params value then apply the change in wavefront for individual alert
2. Moved some update alert status error code to a common function 



**Could you share the test results?**
Test case 1: wavefrontalert  wavefrontalert-pod-restart-sample2 is associated with a single alertconfig lwan3-20210805-usw2-k8s.alertsconfig with one alert 1630616317521 
1. Modified wavefrontalert-pod-restart-sample2 spec condition and displayExpression (changed pod name)
<img width="1080" alt="Screen Shot 2021-09-07 at 2 00 22 PM" src="https://user-images.githubusercontent.com/26155106/132417156-6a3d90b1-403d-4a39-ba4d-08a4b827b865.png">
2. The associated wavefront alert https://intuit.wavefront.com/alerts/1630616317521 was updated
<img width="1389" alt="Screen Shot 2021-09-07 at 2 01 00 PM" src="https://user-images.githubusercontent.com/26155106/132417223-7fe4a489-2ea7-47b2-941d-be552798b5bf.png">

Test case 2: wavefrontalert  wavefrontalert-pod-restart-sample2 is associated with two alertsconfig lwan3-20210805-usw2-k8s.alertsconfig and lwan3-20210819-usw2-k8s with two alerts 1630616317521 and 1631050910871. alertsconfig lwan3-20210819-usw2-k8s was created with two wavefrontalerts templates (wavefrontalert-pod-restart-sample2 and wavefrontalert-pod-restart-sample3)
1. Modified wavefrontalert-pod-restart-sample2 spec condition and displayExpression again (changed back pod name)
2. Associated two alerts https://intuit.wavefront.com/alerts/1631050890764 and https://intuit.wavefront.com/alerts/1630616317521 were updated
<img width="1326" alt="Screen Shot 2021-09-07 at 2 53 34 PM" src="https://user-images.githubusercontent.com/26155106/132417608-8be736ed-3f65-48cc-b183-c49110f5bec0.png">

<img width="1327" alt="Screen Shot 2021-09-07 at 2 53 46 PM" src="https://user-images.githubusercontent.com/26155106/132417620-65fbacf2-ac55-407e-9e8f-6739dfd8664e.png">


3. Alert https://intuit.wavefront.com/alerts/1631050910871 with wavefrontalert-pod-restart-sample3 remains unchanged for alertsconfig lwan3-20210819-usw2-k8s
<img width="1384" alt="Screen Shot 2021-09-07 at 2 46 46 PM" src="https://user-images.githubusercontent.com/26155106/132417592-941d09b0-2382-4708-a825-54daaea2aed2.png">

Test case 3: error handling
1. Update wavefrontalert wavefrontalert-pod-restart-sample2 severity to warning
2. Observed the following log in controller and retries 
```
I0908 16:39:43.353844   69825 event.go:282] Event(v1.ObjectReference{Kind:"WavefrontAlert", Namespace:"dev-iksmanager-usw2-ldev", Name:"wavefrontalert-pod-restart-sample2", UID:"e5f1e146-6435-4a89-a3ab-7952cbf63a60", APIVersion:"alertmanager.keikoproj.io/v1alpha1", ResourceVersion:"699890321", FieldPath:""}): type: 'Warning' reason: 'invalid severity: warning' error occurred in wavefront alert wavefrontalert-pod-restart-sample2
2021-09-08T16:39:43.411-0700	INFO	controllers.common.common.UpdateStatus	Requeue time	{"request_id": "e7c870db-194a-46b3-baff-b7d5b3d6aaeb", "time": 30000}
```
3. wavefrontalert Status
```
spec:
  alertName: pod-restart-2
  alertType: CLASSIC
  condition: max(ratediff(5m, ts(custom.iks.kube.pod.container.status.restarts.total.counter,
    namespace="oil" and pod="k8kinesis-*" and env={{ .env}})), cluster, pod) > {{
    .count}}
  displayExpression: max(ratediff(5m, ts(custom.iks.kube.pod.container.status.restarts.total.counter,
    namespace="oil" and pod="k8kinesis-*" and env={{ .env}})), cluster, pod)
  exportedParams:
  - env
  - count
  - severity
  minutes: 50
  resolveAfterMinutes: 5
  severity: warning
  tags:
  - OIL
  - fluentd
  - preprod
  - restarts
  - alert-test
status:
  alertsStatus:
    lwan3-20210805-usw2-k8s.alertsconfig:
      alertName: pod-restart-2
      associatedAlert:
        CR: wavefrontalert-pod-restart-sample2
      associatedAlertsConfig:
        CR: lwan3-20210805-usw2-k8s.alertsconfig
      id: "1630616317521"
      lastChangeChecksum: d46f4e6ef466e5f99af25adff3dae81d
      link: https://intuit.wavefront.com/alerts/1630616317521
      state: Error
    lwan3-20210819-usw2-k8s:
      alertName: pod-restart-2
      associatedAlert:
        CR: wavefrontalert-pod-restart-sample2
      associatedAlertsConfig:
        CR: lwan3-20210819-usw2-k8s
      id: "1631050890764"
      lastChangeChecksum: 0f469e7770831e707bea64824bcfe9b4
      link: https://intuit.wavefront.com/alerts/1631050890764
      state: Error
  errorDescription: 'invalid severity: warning'
  exportParamsChecksum: c555f101f5e1ce293324c36b8d5f5ffe
  lastChangeChecksum: 9237708219f08abcaec45250bc95dcc4
  observedGeneration: 5
  retryCount: 5
  state: Error
```
4. alertsconfig status
```
spec:
  alerts:
    wavefrontalert-pod-restart-sample2:
      gvk: {}
      params:
        count: "10"
        env: preprod
        severity: warn
  globalGVK:
    group: alertmanager.keikoproj.io
    kind: WavefrontAlert
    version: v1alpha1
status:
  alertsCount: 1
  alertsStatus:
    wavefrontalert-pod-restart-sample2:
      alertName: pod-restart-2
      associatedAlert:
        CR: wavefrontalert-pod-restart-sample2
      associatedAlertsConfig:
        CR: lwan3-20210805-usw2-k8s.alertsconfig
      id: "1630616317521"
      lastChangeChecksum: d46f4e6ef466e5f99af25adff3dae81d
      link: https://intuit.wavefront.com/alerts/1630616317521
      state: Error
  retryCount: 52
  state: Error
```