### PR TITLE
Alertsconfig status state doesn't change from Error to Ready when corrected the invalid severity param value

### DIFF
--- a/controllers/alertsconfig_controller.go
+++ b/controllers/alertsconfig_controller.go
@@ -131,7 +131,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// 2. Wrong alert name and user is going to correct
 			// Ideal way to handle this is to make the alert config status to error and requeue it once in 5 mins or so instead of standard kube builder requeue time
 			// Update the status and retry it
-			return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err, reqChecksum)
+			return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err)
 		}
 		var alert wf.Alert
 		//Get the processed wf alert
@@ -139,7 +139,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		params := utils.MergeMaps(ctx, globalMap, config.Params)
 
 		if err := controllercommon.GetProcessedWFAlert(ctx, &wfAlert, params, &alert); err != nil {
-			return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err, reqChecksum)
+			return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err)
 		}
 		// Create/Update Alert
 		if alertHashMap[alertName].ID == "" {
@@ -153,7 +153,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				}
 				log.Error(err, "unable to create the alert")
 
-				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, state, err, reqChecksum)
+				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, state, err)
 			}
 			alertStatus := alertmanagerv1alpha1.AlertStatus{
 				ID:                 *alert.ID,
@@ -170,7 +170,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 			if err := r.CommonClient.PatchWfAlertAndAlertsConfigStatus(ctx, alertmanagerv1alpha1.Ready, &wfAlert, &alertsConfig, alertStatus); err != nil {
 				log.Error(err, "unable to patch wfalert and alertsconfig status objects")
-				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err, reqChecksum)
+				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err)
 			}
 			log.Info("alert successfully got created", "alertID", alert.ID)
 
@@ -188,7 +188,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				}
 				log.Error(err, "unable to create the alert")
 
-				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, state, err, reqChecksum)
+				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, state, err)
 			}
 
 			alertStatus := alertHashMap[alertName]
@@ -197,7 +197,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			alertStatus.State = alertmanagerv1alpha1.Ready
 			if err := r.CommonClient.PatchWfAlertAndAlertsConfigStatus(ctx, alertmanagerv1alpha1.Ready, &wfAlert, &alertsConfig, alertStatus); err != nil {
 				log.Error(err, "unable to patch wfalert and alertsconfig status objects")
-				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err, reqChecksum)
+				return r.PatchIndividualAlertsConfigError(ctx, &alertsConfig, alertName, alertmanagerv1alpha1.Error, err)
 			}
 			log.Info("alert successfully got updated", "alertID", alert.ID)
 		}
@@ -284,13 +284,11 @@ func (r *AlertsConfigReconciler) DeleteIndividualAlert(ctx context.Context, aler
 
 //PatchIndividualAlertsConfigError function is a utility function to patch the error status
 // We use status patch instead of status update to avoid any overwrite between two threads when alertsConfig CR has multiple alert configs
-func (r *AlertsConfigReconciler) PatchIndividualAlertsConfigError(ctx context.Context, alertsConfig *alertmanagerv1alpha1.AlertsConfig, alertName string, state alertmanagerv1alpha1.State, err error, reqChecksum string, requeueTime ...float64) (ctrl.Result, error) {
+func (r *AlertsConfigReconciler) PatchIndividualAlertsConfigError(ctx context.Context, alertsConfig *alertmanagerv1alpha1.AlertsConfig, alertName string, state alertmanagerv1alpha1.State, err error, requeueTime ...float64) (ctrl.Result, error) {
 	log := log.Logger(ctx, "controllers", "alertsconfig_controller", "PatchIndividualAlertsConfigError")
 	log = log.WithValues("alertsConfig_cr", alertsConfig.Name, "namespace", alertsConfig.Namespace)
 	alertStatus := alertsConfig.Status.AlertsStatus[alertName]
 	alertStatus.State = state
-	// we should update checksum for error cases since the spec was already changed
-	alertStatus.LastChangeChecksum = reqChecksum
 	alertStatusBytes, _ := json.Marshal(alertStatus)
 	retryCount := alertsConfig.Status.RetryCount + 1
 	log.Error(err, "error occured in alerts config for alert name", "alertName", alertName)

--- a/controllers/alertsconfig_controller.go
+++ b/controllers/alertsconfig_controller.go
@@ -114,7 +114,7 @@ func (r *AlertsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// Calculate checksum and compare it with the status checksum
 		exist, reqChecksum := utils.CalculateAlertConfigChecksum(ctx, config, globalMap)
 		// if request and status checksum matches then there is NO change in this specific alert config
-		if exist && alertHashMap[alertName].LastChangeChecksum == reqChecksum {
+		if exist && alertHashMap[alertName].LastChangeChecksum == reqChecksum && alertHashMap[alertName].State != alertmanagerv1alpha1.Error {
 			log.V(1).Info("checksum is equal so there is no change. skipping", "alertName", alertName)
 			//skip it
 			continue


### PR DESCRIPTION
close #27  



**Could you share the solution in high level?**
1. Added the condition to continue to process the alert when alert is in error state
2. Update individual alert status to ready for success case


**Could you share the test results?**
Change the severity to warning will set the state to be error, the lastChangeChecksum was not updated, retry kicked in as expected for this case 
```
spec:
  alerts:
    fluentd-errors:
      gvk: {}
      params:
        clusterName: lwan3-20210805-usw2-k8s
        clusterShortName: lwan3-20210805-usw2
        count: '10'
        severity: warning
  globalGVK:
    group: alertmanager.keikoproj.io
    kind: WavefrontAlert
    version: v1alpha1
status:
  alertsCount: 1
  alertsStatus:
    fluentd-errors:
      alertName: '[SEVERE] lwan3-20210805-usw2-fluentd-errors'
      associatedAlert:
        CR: fluentd-errors
      associatedAlertsConfig:
        CR: lwan3-20210805-usw2-k8s.alertsconfig
      id: '1632347139454'
      lastChangeChecksum: 3aad3692603cf21263c52804b633d5be
      link: 'https://intuit.wavefront.com/alerts/1632347139454'
      state: Error
```

Change the severity back to warn will set the state to be Ready and lastChangeChecksum was not updated
```
spec:
  alerts:
    fluentd-errors:
      gvk: {}
      params:
        clusterName: lwan3-20210805-usw2-k8s
        clusterShortName: lwan3-20210805-usw2
        count: '10'
        severity: warn
  globalGVK:
    group: alertmanager.keikoproj.io
    kind: WavefrontAlert
    version: v1alpha1
status:
  alertsCount: 1
  alertsStatus:
    fluentd-errors:
      alertName: '[SEVERE] lwan3-20210805-usw2-fluentd-errors'
      associatedAlert:
        CR: fluentd-errors
      associatedAlertsConfig:
        CR: lwan3-20210805-usw2-k8s.alertsconfig
      id: '1632347139454'
      lastChangeChecksum: 3aad3692603cf21263c52804b633d5be
      link: 'https://intuit.wavefront.com/alerts/1632347139454'
      state: Ready
```