### PR TITLE
adding condition for standalone alerts

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	alertmanagerv1alpha1 "github.com/keikoproj/alert-manager/api/v1alpha1"
 	"github.com/keikoproj/alert-manager/internal/template"
@@ -151,6 +152,14 @@ func GetProcessedWFAlert(ctx context.Context, wfAlert *alertmanagerv1alpha1.Wave
 	wfAlertBytes, err := json.Marshal(wfAlert.Spec)
 	if err != nil {
 		// update the status and retry it
+		return err
+	}
+
+	//standalone alert
+	if len(wfAlert.Spec.ExportedParams) == 0 {
+		errMsg := "cannot use standalone alert with alertsconfig. must have exportedParams in wavefrontalert cr"
+		err := errors.New(errMsg)
+		log.Error(err, errMsg)
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,8 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	golang.org/x/mod v0.5.1 // indirect
-	golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef // indirect
+	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
+	//golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
 	golang.org/x/tools v0.1.7 // indirect
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -607,6 +607,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYe
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
 golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac h1:oN6lz7iLW/YC7un8pq+9bOLyXrprv2+DKfkJY+2LJJw=
+golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Signed-off-by: mnkg561 <mnkg561@gmail.com>

close https://github.com/keikoproj/alert-manager/issues/34

**Could you share the solution in high level?**
Check the exportedParams length before proceeding further. It is intentional to put the status in error so users must go back and correct the CR by removing the standalone alert from the spec


**Could you share the test results?**