### PR TITLE
supporting check alert frequency

### DIFF
--- a/api/v1alpha1/wavefrontalert_types.go
+++ b/api/v1alpha1/wavefrontalert_types.go
@@ -80,6 +80,10 @@ type WavefrontAlertSpec struct {
 	// wants to use go lang template for a field but majority of the alerts can use the default values instead of providing in each and every alert config files.
 	// +optional
 	ExportedParamsDefaultValues OrderedMap `json:"exportedParamsDefaultValues,omitempty"`
+
+	//AlertCheckFrequency can be used to provide a different alert check frequency then the default 1min. Optional. This is in minutes
+	// +optional
+	AlertCheckFrequency int `json:"alertCheckFrequency,omitempty"`
 }
 
 // AlertType represents the type of the Alert in Wavefront. Defaults to CLASSIC alert

--- a/config/crd/bases/alertmanager.keikoproj.io_wavefrontalerts.yaml
+++ b/config/crd/bases/alertmanager.keikoproj.io_wavefrontalerts.yaml
@@ -54,6 +54,11 @@ spec:
               additionalInformation:
                 description: Any additional information, such as a link to a run book.
                 type: string
+              alertCheckFrequency:
+                description: AlertCheckFrequency can be used to provide a different
+                  alert check frequency then the default 1min. Optional. This is in
+                  minutes
+                type: integer
               alertName:
                 description: Name of the alert to be created in Wavefront
                 type: string

--- a/config/samples/alertmanager_v1alpha1_wavefrontalert.yaml
+++ b/config/samples/alertmanager_v1alpha1_wavefrontalert.yaml
@@ -9,7 +9,7 @@ spec:
   condition: ts(status.health)
   displayExpression: ts(status.health)
   minutes: 5
-  resolveAfterMinutes: 5
+  resolveAfterMinutes: 50
   severity: severe
   tags:
     - test-alert

--- a/config/samples/alertmanager_v1alpha1_wavefrontalert3.yaml
+++ b/config/samples/alertmanager_v1alpha1_wavefrontalert3.yaml
@@ -11,6 +11,7 @@ spec:
   minutes: 50
   resolveAfterMinutes: 5
   severity: "{{.bar}}"
+  alertCheckFrequency: 5
   exportedParams:
     - foo
     - bar

--- a/config/samples/alertmanager_v1alpha1_wavefrontalert4.yaml
+++ b/config/samples/alertmanager_v1alpha1_wavefrontalert4.yaml
@@ -11,6 +11,7 @@ spec:
   minutes: 50
   resolveAfterMinutes: 5
   severity: "{{.bar}}"
+  alertCheckFrequency: 5
   exportedParams:
     - foo
     - bar

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	golang.org/x/mod v0.5.1 // indirect
-	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
+	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	//golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
 	golang.org/x/tools v0.1.7 // indirect
 	k8s.io/api v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -609,6 +609,8 @@ golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ
 golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac h1:oN6lz7iLW/YC7un8pq+9bOLyXrprv2+DKfkJY+2LJJw=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
+golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/wavefront/conversion.go
+++ b/pkg/wavefront/conversion.go
@@ -28,6 +28,9 @@ func ConvertAlertCRToWavefrontRequest(ctx context.Context, req v1alpha1.Wavefron
 	alert.Minutes = int(*req.Minutes)
 	alert.ResolveAfterMinutes = int(*req.ResolveAfter)
 	alert.Target = req.Target
+	if req.AlertCheckFrequency != 0 {
+		alert.CheckingFrequencyInMinutes = req.AlertCheckFrequency
+	}
 	log.V(1).Info("alert conversion is successful")
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: mnkg561 <mnkg561@gmail.com>

close https://github.com/keikoproj/alert-manager/issues/43


**Could you share the solution in high level?**
Upon checking the wavefront api library we found that AlertCheckFrequency is the field which supports. Provided an optional field "alertCheckFrequency" in the CRD where user can provide a value(in mins) to configure it.

**Could you share the test results?**

CR:

```
apiVersion: alertmanager.keikoproj.io/v1alpha1
kind: WavefrontAlert
metadata:
  name: wavefrontalert-sample3
spec:
  # Add fields here
  alertType: CLASSIC
  alertName: test-alert4
  condition: ts({{ .foo}})
  displayExpression: ts({{ .zzz }})
  minutes: 50
  resolveAfterMinutes: 5
  severity: "{{.bar}}"
  alertCheckFrequency: 5
  exportedParams:
    - foo
    - bar
    - zzz
  tags:
    - test-alert
    - something-weird
  ```

Result:
<img width="1202" alt="Screen Shot 2021-12-03 at 11 25 50 AM" src="https://user-images.githubusercontent.com/6040874/144661746-ba74c288-c8b8-4133-88ad-952ff43cb6f3.png">

