### PR TITLE
Fixed resources names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/config/crd/bases/alertmanager.keikoproj.io_configmap.yaml
+++ b/config/crd/bases/alertmanager.keikoproj.io_configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: alert-manager-configmap
+  name: configmap
 data:
   wavefront.api.url: "try.wavefront.com"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -11,10 +11,10 @@ spec:
         args:
         - "--config=controller_manager_config.yaml"
         volumeMounts:
-        - name: manager-config
+        - name: config
           mountPath: /controller_manager_config.yaml
           subPath: controller_manager_config.yaml
       volumes:
-      - name: manager-config
+      - name: config
         configMap:
-          name: manager-config
+          name: config

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,7 +7,7 @@ generatorOptions:
 configMapGenerator:
 - files:
   - controller_manager_config.yaml
-  name: manager-config
+  name: config
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: role
 rules:
 - apiGroups:
   - alertmanager.keikoproj.io

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: role
 subjects:
 - kind: ServiceAccount
   name: controller-manager


### PR DESCRIPTION
close #45 



**Could you share the solution in high level?**
Few resources such as ConfigMap, Role which are referenced inside kustomize already has `alert-manager-` as prefix but these resources are additionally named as alert-manager which is making the name attached wrongly during deployment. For example one configmap is named as:
`alert-manager-alert-manager-configmap`


**Could you share the test results?**
Resources:
```
namespace/alert-manager-system created
customresourcedefinition.apiextensions.k8s.io/alertsconfigs.alertmanager.keikoproj.io created
customresourcedefinition.apiextensions.k8s.io/wavefrontalerts.alertmanager.keikoproj.io created
serviceaccount/alert-manager-controller-manager created
role.rbac.authorization.k8s.io/alert-manager-leader-election-role created
clusterrole.rbac.authorization.k8s.io/alert-manager-metrics-reader created
clusterrole.rbac.authorization.k8s.io/alert-manager-proxy-role created
clusterrole.rbac.authorization.k8s.io/alert-manager-role created
rolebinding.rbac.authorization.k8s.io/alert-manager-leader-election-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/alert-manager-proxy-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/alert-manager-rolebinding created
configmap/alert-manager-config created
configmap/alert-manager-configmap created
service/alert-manager-controller-manager-metrics-service created
deployment.apps/alert-manager-controller-manager created
```

configmap:
```
apiVersion: v1
data:
  controller_manager_config.yaml: |
    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
    kind: ControllerManagerConfig
    health:
      healthProbeBindAddress: :<>
    metrics:
      bindAddress: <>
    webhook:
      port: 9443
    leaderElection:
      leaderElect: true
      resourceName: <>
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      <>
  creationTimestamp: "2022-06-29T03:23:31Z"
  name: alert-manager-config
  namespace: alert-manager-system
  resourceVersion: <>
  uid: <>

---

apiVersion: v1
data:
  wavefront.api.url: try.wavefront.com
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      <>
  creationTimestamp: "2022-06-29T03:23:32Z"
  name: alert-manager-configmap
  namespace: alert-manager-system
  resourceVersion: <>
  uid: <>

```

Role:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      <>
  creationTimestamp: "2022-06-29T03:23:28Z"
  name: alert-manager-role
  resourceVersion: <>
  uid: <>
rules:
- apiGroups:
  - alertmanager.keikoproj.io
  resources:
  - alertsconfigs
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - alertmanager.keikoproj.io
  resources:
  - alertsconfigs/finalizers
  verbs:
  - update
- apiGroups:
  - alertmanager.keikoproj.io
  resources:
  - alertsconfigs/status
  verbs:
  - get
  - patch
  - update
- apiGroups:
  - alertmanager.keikoproj.io
  resources:
  - wavefrontalerts
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - alertmanager.keikoproj.io
  resources:
  - wavefrontalerts/finalizers
  verbs:
  - update
- apiGroups:
  - alertmanager.keikoproj.io
  resources:
  - wavefrontalerts/status
  verbs:
  - get
  - patch
  - update
- apiGroups:
  - ""
  resources:
  - events
  verbs:
  - create
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
```

Role Binding:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      <>
  creationTimestamp: "2022-06-29T03:23:30Z"
  name: alert-manager-rolebinding
  resourceVersion: <>
  uid: <>
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: alert-manager-role
subjects:
- kind: ServiceAccount
  name: alert-manager-controller-manager
  namespace: alert-manager-system
```

Functional Test:
```
Using cached envtest tools from <>
setting up env vars
?       github.com/keikoproj/alert-manager      [no test files]
?       github.com/keikoproj/alert-manager/api/v1alpha1 [no test files]
ok      github.com/keikoproj/alert-manager/controllers  12.851s coverage: 20.2% of statements
ok      github.com/keikoproj/alert-manager/controllers/common   13.159s coverage: 35.7% of statements
?       github.com/keikoproj/alert-manager/controllers/mocks    [no test files]
?       github.com/keikoproj/alert-manager/internal/config      [no test files]
?       github.com/keikoproj/alert-manager/internal/config/common       [no test files]
ok      github.com/keikoproj/alert-manager/internal/template    1.300s  coverage: 66.7% of statements
ok      github.com/keikoproj/alert-manager/internal/utils       0.973s  coverage: 76.2% of statements
ok      github.com/keikoproj/alert-manager/pkg/k8s      12.259s coverage: 0.0% of statements
?       github.com/keikoproj/alert-manager/pkg/log      [no test files]
ok      github.com/keikoproj/alert-manager/pkg/wavefront        1.672s  coverage: 60.6% of statements
```

WavefrontAlert CR:
```
kubectl describe WavefrontAlert
Name:        <>
Namespace:    kube-system
Labels:       <none>
Annotations:  <none>
API Version:  alertmanager.keikoproj.io/v1alpha1
Kind:         WavefrontAlert
Metadata:
  Creation Timestamp:  2022-07-01T05:14:31Z
  Finalizers:
    wavefrontalert.finalizers.alertmanager.keikoproj.io
  Generation:  1
  Managed Fields:
    API Version:  alertmanager.keikoproj.io/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:kubectl.kubernetes.io/last-applied-configuration:
      f:spec:
        .:
        f:additionalInformation:
        f:alertCheckFrequency:
        f:alertName:
        f:alertType:
        f:condition:
        f:displayExpression:
        f:exportedParams:
        f:minutes:
        f:resolveAfterMinutes:
        f:severity:
        f:tags:
        f:target:
    Manager:      kubectl-client-side-apply
    Operation:    Update
    Time:         2022-07-01T05:14:31Z
    API Version:  alertmanager.keikoproj.io/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"wavefrontalert.finalizers.alertmanager.keikoproj.io":
      f:status:
        .:
        f:exportParamsChecksum:
        f:lastChangeChecksum:
        f:observedGeneration:
        f:retryCount:
        f:state:
    Manager:         manager
    Operation:       Update
    Time:            2022-07-01T05:14:31Z
  Resource Version:  <>
  UID:               <>
Spec:
  Additional Information:  <>
  Alert Check Frequency:   1
  Alert Name:             <>
  Alert Type:              CLASSIC
  Condition:               <>
  Display Expression:      <>
  Exported Params:
    clusterName
    clusterShortName
    region
  Minutes:                1
  Resolve After Minutes:  1
  Severity:               warn
  Tags:
    <>
  Target:  <>
Status:
  Alerts Status:
    Alertsconfig:
      Alert Name:  <>
      Associated Alert:
        CR:          <>
        Generation:  1
      Associated Alerts Config:
        CR:                    alertsconfig
      Error Description:
      Id:                      1656659817850
      Last Change Checksum:    dd496134e01c7f8fd4e3ea4e2adf0213
      Last Updated Timestamp:  2022-07-01T07:16:57Z
      Link:                    https://try.wavefront.com/alerts/1656659817850
      State:                   Ready
  Export Params Checksum:      <>
  Last Change Checksum:        <>
  Observed Generation:         1
  Retry Count:                 0
  State:                       Ready
Events:
  Type    Reason      Age   From                      Message
  ----    ------      ----  ----                      -------
  Normal  Successful  9s    alert-manager-controller  successfully created/updated an alert name = <>
```