### PR TITLE
Update controller-gen to v0.17.0 and makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd rbac:roleName=role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,10 @@ test: mock manifests generate fmt vet envtest ## Run tests.
 
 ##@ Build
 
-build: mock generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+.PHONY: build
+build: $(LOCALBIN)/manager
+$(LOCALBIN)/manager: generate fmt vet ## Build manager binary.
+	go build -o $(LOCALBIN)/manager cmd/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run cmd/main.go

--- a/config/crd/bases/alertmanager.keikoproj.io_alertsconfigs.yaml
+++ b/config/crd/bases/alertmanager.keikoproj.io_alertsconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: alertsconfigs.alertmanager.keikoproj.io
 spec:
   group: alertmanager.keikoproj.io
@@ -33,14 +33,19 @@ spec:
         description: AlertsConfig is the Schema for the alertsconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -80,10 +85,9 @@ spec:
                 description: Alerts- Provide each individual alert config
                 type: object
               globalGVK:
-                description: GlobalGVK- This is a global GVK config but user can overwrite
-                  it if an AlertsConfig supports multiple type of Alerts in future.
-                  This CRD must be installed in the cluster otherwise AlertsConfig
-                  will go into error state
+                description: |-
+                  GlobalGVK- This is a global GVK config but user can overwrite it if an AlertsConfig supports multiple type of Alerts in future.
+                  This CRD must be installed in the cluster otherwise AlertsConfig will go into error state
                 properties:
                   group:
                     description: Group - CRD Group name which this config/s is related
@@ -101,11 +105,10 @@ spec:
               globalParams:
                 additionalProperties:
                   type: string
-                description: GlobalParams is the place holder to provide any global
-                  param values which can be used in individual config sections. Please
-                  note that if a param is mentioned in both global param section and
-                  individual config params section, later will be taken into consideration
-                  and NOT the value from global param section
+                description: |-
+                  GlobalParams is the place holder to provide any global param values which can be used in individual config sections.
+                  Please note that if a param is mentioned in both global param section and individual config params section,
+                  later will be taken into consideration and NOT the value from global param section
                 type: object
             type: object
           status:

--- a/config/crd/bases/alertmanager.keikoproj.io_wavefrontalerts.yaml
+++ b/config/crd/bases/alertmanager.keikoproj.io_wavefrontalerts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.17.0
   name: wavefrontalerts.alertmanager.keikoproj.io
 spec:
   group: alertmanager.keikoproj.io
@@ -35,14 +35,19 @@ spec:
         description: WavefrontAlert is the Schema for the wavefrontalerts API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -81,22 +86,18 @@ spec:
                   the alert changes state
                 type: string
               exportedParams:
-                description: exportedParams can be used when AlertsConfig CRD used
-                  to provide config to WavefrontAlert CRD at the runtime for multiple
-                  alerts when the exportedParams length is not empty, Alert will not
-                  be created when Alert CR is created but rather alerts will be created
-                  when AlertsConfig CR created.
+                description: |-
+                  exportedParams can be used when AlertsConfig CRD used to provide config to WavefrontAlert CRD at the runtime for multiple alerts
+                  when the exportedParams length is not empty, Alert will not be created when Alert CR is created but rather alerts will be created when AlertsConfig CR created.
                 items:
                   type: string
                 type: array
               exportedParamsDefaultValues:
                 additionalProperties:
                   type: string
-                description: exportedParamsDefaultValues can be used to provide the
-                  default values and will be used if alerts config doesn't provide
-                  any values. This could be useful if user wants to use go lang template
-                  for a field but majority of the alerts can use the default values
-                  instead of providing in each and every alert config files.
+                description: |-
+                  exportedParamsDefaultValues can be used to provide the default values and will be used if alerts config doesn't provide any values. This could be useful if user
+                  wants to use go lang template for a field but majority of the alerts can use the default values instead of providing in each and every alert config files.
                 type: object
               minutes:
                 description: Minutes where alert is in "true" state continuously to
@@ -118,10 +119,10 @@ spec:
                   type: string
                 type: array
               target:
-                description: 'Target (Optional) A comma-separated list of the email
-                  address or integration endpoint (such as PagerDuty or web hook)
-                  to notify when the alert status changes. Multiple target types can
-                  be in the list. Alert target format: ({email}|pd:{pd_key}'
+                description: |-
+                  Target (Optional) A comma-separated list of the email address or integration endpoint (such as PagerDuty or web hook)
+                  to notify when the alert status changes.
+                  Multiple target types can be in the list. Alert target format: ({email}|pd:{pd_key}
                 type: string
             required:
             - alertName

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,58 +5,6 @@ metadata:
   name: role
 rules:
 - apiGroups:
-  - alertmanager.keikoproj.io
-  resources:
-  - alertsconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - alertmanager.keikoproj.io
-  resources:
-  - alertsconfigs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - alertmanager.keikoproj.io
-  resources:
-  - alertsconfigs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - alertmanager.keikoproj.io
-  resources:
-  - wavefrontalerts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - alertmanager.keikoproj.io
-  resources:
-  - wavefrontalerts/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - alertmanager.keikoproj.io
-  resources:
-  - wavefrontalerts/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - ""
   resources:
   - events
@@ -75,3 +23,32 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - alertmanager.keikoproj.io
+  resources:
+  - alertsconfigs
+  - wavefrontalerts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - alertmanager.keikoproj.io
+  resources:
+  - alertsconfigs/finalizers
+  - wavefrontalerts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - alertmanager.keikoproj.io
+  resources:
+  - alertsconfigs/status
+  - wavefrontalerts/status
+  verbs:
+  - get
+  - patch
+  - update


### PR DESCRIPTION
## Makefile Updates
- Updated controller-gen version from v0.13.0 to v0.17.0
- Removed the deprecated CRD_OPTIONS variable that was previously set to "crd"
- Modified the controller-gen installation and management approach:
  - Changed from using a find-or-install approach to a dependency-based approach
  - Now using `$(LOCALBIN)` to install tools in the project's bin directory
  - Improved dependency tracking for build tools
- Simplified the manifests generation command by removing the CRD_OPTIONS variable from the controller-gen command

## Build Tool Management
- Restructured the tooling section of the Makefile to be more maintainable
- Added proper dependency tracking for the controller-gen binary
- Aligned with modern Kubernetes controller project practices
- Addressed ARM64 architecture compatibility issues (for M-series Mac)

## Kustomize Configuration
- Maintained consistent approach to Kustomize installation
- Kept the use of the Kustomize install script from the Kubernetes repository

These changes primarily improve build tool compatibility with ARM64 architecture and modernize the Makefile structure. The update to controller-gen v0.17.0 aims to resolve the nil pointer dereference errors that were occurring during code generation on Mac M-series processors.
