### PR TITLE
Add Codecov token to workflow for proper coverage reporting

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -42,3 +42,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           file: ./cover.out
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Fix Codecov Integration for Coverage Reporting

## Problem

Currently, code coverage data is not being reported properly to Codecov for this repository. All PRs have pending checks, and coverage data is not visible on the Codecov dashboard, particularly for the master branch.

## Solution

This PR adds a Codecov token parameter to the unit test workflow to properly authenticate with Codecov when uploading coverage data. The `codecov/codecov-action` requires authentication via a token for proper integration.

```diff
 - name: Upload coverage
   uses: codecov/codecov-action@v5
   with:
     file: ./cover.out
+    token: ${{ secrets.CODECOV_TOKEN }}