### PR TITLE
chore: standardize GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,60 @@
+---
+name: Bug Report
+about: Report a bug in the project
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+
+<!-- Provide a clear and concise description of the bug -->
+
+## Steps To Reproduce
+
+<!-- Provide detailed steps to reproduce the behavior -->
+
+1. Step one
+2. Step two
+3. Step three
+
+## Expected Behavior
+
+<!-- Describe what you expected to happen -->
+
+## Actual Behavior
+
+<!-- Describe what actually happened -->
+
+## Screenshots/Logs
+
+<!-- If applicable, add screenshots or logs to help explain your problem -->
+
+## Environment
+
+<!-- Please complete the following information -->
+
+- Version: <!-- e.g., v0.1.0 -->
+- Kubernetes version: <!-- e.g., v1.25.0 -->
+- Cloud Provider: <!-- e.g., AWS, GCP, Azure -->
+- Installation method: <!-- e.g., Helm, kubectl, operator -->
+- OS: <!-- e.g., Ubuntu 22.04, macOS 13 -->
+- Browser (if applicable): <!-- e.g., Chrome 99 -->
+
+## Additional Context
+
+<!-- Add any other context about the problem here -->
+<!-- For example: Is this a regression? Did it use to work in an earlier version? -->
+
+## Impact
+
+<!-- How is this bug affecting your use of the project? -->
+
+- [ ] Blocking (cannot proceed with work)
+- [ ] High (significant workaround needed)
+- [ ] Medium (minor workaround needed)
+- [ ] Low (inconvenience)
+
+## Possible Solution
+
+<!-- Optional: If you have suggestions on a fix for the bug -->

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,0 +1,33 @@
+---
+name: Documentation Issue
+about: Report issues with documentation or suggest improvements
+title: '[DOCS] '
+labels: documentation
+assignees: ''
+---
+
+## Documentation Issue
+
+<!-- Describe the issue with the documentation -->
+<!-- Examples: "Information is missing for...", "Instructions are unclear for...", "Documentation is outdated for..." -->
+
+## Page/Location
+
+<!-- Provide links to the relevant documentation pages or sections -->
+<!-- For example: "README.md#installation" or "https://website.com/docs/getting-started" -->
+
+## Suggested Changes
+
+<!-- How could the documentation be improved? -->
+<!-- Be as specific as possible. If you have exact wording suggestions, include them here -->
+
+## Additional Information
+
+<!-- Any other context that might be helpful -->
+<!-- Screenshots of the problematic documentation or examples of better documentation elsewhere are welcome -->
+
+## Would you be willing to contribute this documentation improvement?
+
+<!-- Let us know if you'd be interested in submitting a PR with the fix -->
+- [ ] Yes, I can submit a PR with the changes
+- [ ] No, I'm not able to contribute documentation for this

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature Request
+about: Suggest an enhancement or new feature
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+<!-- Describe the problem that this feature would solve -->
+<!-- Examples: "I'm always frustrated when..." or "It would be useful to have..." -->
+
+## Proposed Solution
+
+<!-- Describe the solution you'd like -->
+<!-- Clear and concise description of what you want to happen -->
+
+## Alternatives Considered
+
+<!-- Describe any alternative solutions or features you've considered -->
+<!-- What workarounds are you using currently, if any? -->
+
+## User Value
+
+<!-- Explain how this feature would provide value to users of the project -->
+<!-- How would this improve your workflow or the project overall? -->
+
+## Implementation Ideas
+
+<!-- Optional: If you have specific ideas about how this could be implemented -->
+<!-- Technical details, architecture, or code examples can go here -->
+
+## Additional Context
+
+<!-- Add any other context, screenshots, or examples about the feature request here -->
+
+## Would you be willing to contribute this feature?
+
+<!-- Let us know if you'd be interested in implementing this feature yourself -->
+- [ ] Yes, I'd like to implement this feature
+- [ ] I could contribute partially
+- [ ] No, I'm not able to contribute code for this

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,37 @@
+---
+name: Question or Support Request
+about: Ask a question or request support
+title: '[QUESTION] '
+labels: question
+assignees: ''
+---
+
+## Question
+
+<!-- Clearly state your question -->
+
+## Context
+
+<!-- Provide any relevant context for your question -->
+<!-- What are you trying to accomplish? What have you tried so far? -->
+
+## Environment (if relevant)
+
+<!-- If your question relates to a specific environment, please provide details -->
+- Version: <!-- e.g., v0.1.0 -->
+- Kubernetes version: <!-- e.g., v1.25.0 -->
+- Cloud Provider: <!-- e.g., AWS, GCP, Azure -->
+- OS: <!-- e.g., Ubuntu 22.04, macOS 13 -->
+
+## Screenshots/Logs (if applicable)
+
+<!-- If relevant, include any screenshots or logs -->
+
+## Related Documentation
+
+<!-- Have you already checked any related documentation? If so, please link it here -->
+
+## Search Terms
+
+<!-- What terms did you search for before opening this question? -->
+<!-- This helps us improve our documentation and search functionality -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,58 @@
+<!-- 
+Please make sure you've read and understood our contributing guidelines.
+If this is a bug fix, make sure your description includes "fixes #xxxx", or
+"closes #xxxx", where #xxxx is the issue number.
+
+Please provide the following information:
+-->
+
+## What type of PR is this?
+<!-- Please check all that apply -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Feature/Enhancement (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] Performance improvement
+- [ ] Test updates
+- [ ] CI/CD related changes
+- [ ] Dependency upgrade
+
+## Description
+<!-- Please explain the changes you made here. -->
+
+## Related issue(s)
+<!-- Please link the issue being fixed, e.g. Fixes #123 -->
+
+## High-level overview of changes
+<!-- 
+Provide a high-level description of what changes were made and why.
+This helps reviewers understand your approach.
+-->
+
+## Testing performed
+<!-- 
+Describe the testing you've done:
+- Unit tests added/modified
+- Integration tests
+- Manual testing performed 
+- Any test outputs/results
+-->
+
+## Checklist
+<!-- Please check all that apply -->
+
+- [ ] I've read the [CONTRIBUTING](/CONTRIBUTING.md) doc
+- [ ] I've added/updated tests that prove my fix is effective or that my feature works
+- [ ] I've added necessary documentation (if appropriate)
+- [ ] I've run `make test` locally and all tests pass
+- [ ] I've signed-off my commits with `git commit -s` for DCO verification
+- [ ] I've updated any relevant documentation
+- [ ] Code follows the style guidelines of this project
+
+## Additional information
+<!--
+Any other information that is important to this PR, such as screenshots 
+of how the component looks before and after the change.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,0 @@
-close 
-
-
-
-**Could you share the solution in high level?**
-
-
-
-**Could you share the test results?**


### PR DESCRIPTION
Standardize issue and PR templates to improve contributor experience

- Update PR template with consistent formatting

- Add structured issue templates for bug reports, feature requests, documentation issues, and questions

- Remove old single issue template

- Rename PR template to follow GitHub conventions

close 



**Could you share the solution in high level?**



**Could you share the test results?**